### PR TITLE
MATH-1345 - Raise error rather than silently fail

### DIFF
--- a/lib/adapter_extensions/adapters/postgresql_adapter.rb
+++ b/lib/adapter_extensions/adapters/postgresql_adapter.rb
@@ -96,7 +96,10 @@ protected
     ensure
       conn.put_copy_end
       io.close
-      conn.get_result.check
     end
+    
+    res = conn.get_result
+    STDOUT.puts "Copy Result: #{res.res_status(res.result_status)} on #{res.cmd_tuples}"
+    res.check
   end
 end

--- a/lib/adapter_extensions/adapters/postgresql_adapter.rb
+++ b/lib/adapter_extensions/adapters/postgresql_adapter.rb
@@ -43,7 +43,7 @@ protected
     execute(q)
   end
 
-  DEFAULT_BUFFER_SIZE = 256
+  DEFAULT_BUFFER_SIZE = 1024
 
   # Call +bulk_load+, as that method wraps this method.
   #
@@ -96,6 +96,7 @@ protected
     ensure
       conn.put_copy_end
       io.close
+      conn.get_result.check
     end
   end
 end


### PR DESCRIPTION
If a copy fails for some reason, we just silently fail and are never the wiser. This change will raise the error so that we can see it in Bugsnag and/or Papertrail logs.

Forks and Band-aids, baby!!